### PR TITLE
Fixed loading "Microsoft.EntityFrameworkCore.DynamicLinq.DynamicFunctions"

### DIFF
--- a/src/System.Linq.Dynamic.Core/Parser/PredefinedTypesHelper.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/PredefinedTypesHelper.cs
@@ -1,11 +1,14 @@
 ﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq.Dynamic.Core.Validation;
+using System.Text.RegularExpressions;
 
 namespace System.Linq.Dynamic.Core.Parser
 {
     internal static class PredefinedTypesHelper
     {
+        private static readonly string Version = Regex.Match(typeof(PredefinedTypesHelper).AssemblyQualifiedName, @"\d+\.\d+\.\d+\.\d+").ToString();
+
         // These shorthands have different name than actual type and therefore not recognized by default from the PredefinedTypes.
         public static readonly IDictionary<string, Type> PredefinedTypesShorthands = new Dictionary<string, Type>
         {
@@ -63,7 +66,7 @@ namespace System.Linq.Dynamic.Core.Parser
 #endif
 
 #if NETSTANDARD2_0
-            TryAdd("Microsoft.EntityFrameworkCore.DynamicLinq.DynamicFunctions, Microsoft.EntityFrameworkCore.DynamicLinq, Version=1.0.0.0, Culture=neutral, PublicKeyToken=974e7e1b462f3693", 3);
+            TryAdd($"Microsoft.EntityFrameworkCore.DynamicLinq.DynamicFunctions, Microsoft.EntityFrameworkCore.DynamicLinq, Version={Version}, Culture=neutral, PublicKeyToken=974e7e1b462f3693", 3);
 #endif
         }
 
@@ -94,7 +97,7 @@ namespace System.Linq.Dynamic.Core.Parser
                 return true;
             }
 
-            return config.CustomTypeProvider != null && 
+            return config.CustomTypeProvider != null &&
                    (config.CustomTypeProvider.GetCustomTypes().Contains(type) || config.CustomTypeProvider.GetCustomTypes().Contains(nonNullableType));
         }
     }


### PR DESCRIPTION
Because of the file-version fix: another fix is needed #390 else the DynamicFunctions class is not loaded anymore.