### PR TITLE
Use parameterized names in dynamic query

### DIFF
--- a/src/System.Linq.Dynamic.Core/Parser/ConstantExpressionWrapper.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/ConstantExpressionWrapper.cs
@@ -16,13 +16,25 @@ namespace System.Linq.Dynamic.Core.Parser
                 {
                     expression = WrappedConstant((bool)constantExpression.Value);
                 }
+                else if (constantExpression.Type == typeof(bool?))
+                {
+                    expression = WrappedConstant((bool?)constantExpression.Value);
+                }
                 else if (constantExpression.Type == typeof(char))
                 {
                     expression = WrappedConstant((char)constantExpression.Value);
                 }
+                else if (constantExpression.Type == typeof(char?))
+                {
+                    expression = WrappedConstant((char?)constantExpression.Value);
+                }
                 else if (constantExpression.Type == typeof(byte))
                 {
                     expression = WrappedConstant((byte)constantExpression.Value);
+                }
+                else if (constantExpression.Type == typeof(byte?))
+                {
+                    expression = WrappedConstant((byte?)constantExpression.Value);
                 }
                 else if (constantExpression.Type == typeof(sbyte))
                 {
@@ -36,53 +48,105 @@ namespace System.Linq.Dynamic.Core.Parser
                 {
                     expression = WrappedConstant((float)constantExpression.Value);
                 }
+                else if (constantExpression.Type == typeof(float?))
+                {
+                    expression = WrappedConstant((float?)constantExpression.Value);
+                }
                 else if (constantExpression.Type == typeof(decimal))
                 {
                     expression = WrappedConstant((decimal)constantExpression.Value);
+                }
+                else if (constantExpression.Type == typeof(decimal?))
+                {
+                    expression = WrappedConstant((decimal?)constantExpression.Value);
                 }
                 else if (constantExpression.Type == typeof(double))
                 {
                     expression = WrappedConstant((double)constantExpression.Value);
                 }
+                else if (constantExpression.Type == typeof(double?))
+                {
+                    expression = WrappedConstant((double?)constantExpression.Value);
+                }
                 else if (constantExpression.Type == typeof(long))
                 {
                     expression = WrappedConstant((long)constantExpression.Value);
+                }
+                else if (constantExpression.Type == typeof(long?))
+                {
+                    expression = WrappedConstant((long?)constantExpression.Value);
                 }
                 else if (constantExpression.Type == typeof(ulong))
                 {
                     expression = WrappedConstant((ulong)constantExpression.Value);
                 }
+                else if (constantExpression.Type == typeof(ulong?))
+                {
+                    expression = WrappedConstant((ulong?)constantExpression.Value);
+                }
                 else if (constantExpression.Type == typeof(int))
                 {
                     expression = WrappedConstant((int)constantExpression.Value);
+                }
+                else if (constantExpression.Type == typeof(int?))
+                {
+                    expression = WrappedConstant((int?)constantExpression.Value);
                 }
                 else if (constantExpression.Type == typeof(uint))
                 {
                     expression = WrappedConstant((uint)constantExpression.Value);
                 }
+                else if (constantExpression.Type == typeof(uint?))
+                {
+                    expression = WrappedConstant((uint?)constantExpression.Value);
+                }
                 else if (constantExpression.Type == typeof(short))
                 {
                     expression = WrappedConstant((short)constantExpression.Value);
+                }
+                else if (constantExpression.Type == typeof(short?))
+                {
+                    expression = WrappedConstant((short?)constantExpression.Value);
                 }
                 else if (constantExpression.Type == typeof(ushort))
                 {
                     expression = WrappedConstant((ushort)constantExpression.Value);
                 }
+                else if (constantExpression.Type == typeof(ushort?))
+                {
+                    expression = WrappedConstant((ushort?)constantExpression.Value);
+                }
                 else if (constantExpression.Type == typeof(Guid))
                 {
                     expression = WrappedConstant((Guid)constantExpression.Value);
+                }
+                else if (constantExpression.Type == typeof(Guid?))
+                {
+                    expression = WrappedConstant((Guid?)constantExpression.Value);
                 }
                 else if (constantExpression.Type == typeof(DateTime))
                 {
                     expression = WrappedConstant((DateTime)constantExpression.Value);
                 }
+                else if (constantExpression.Type == typeof(DateTime?))
+                {
+                    expression = WrappedConstant((DateTime?)constantExpression.Value);
+                }
                 else if (constantExpression.Type == typeof(DateTimeOffset))
                 {
                     expression = WrappedConstant((DateTimeOffset)constantExpression.Value);
                 }
+                else if (constantExpression.Type == typeof(DateTimeOffset?))
+                {
+                    expression = WrappedConstant((DateTimeOffset?)constantExpression.Value);
+                }
                 else if (constantExpression.Type == typeof(TimeSpan))
                 {
                     expression = WrappedConstant((TimeSpan)constantExpression.Value);
+                }
+                else if (constantExpression.Type == typeof(TimeSpan?))
+                {
+                    expression = WrappedConstant((TimeSpan?)constantExpression.Value);
                 }
 
                 return;
@@ -94,17 +158,33 @@ namespace System.Linq.Dynamic.Core.Parser
                 {
                     expression = WrappedConstant(Expression.Lambda<Func<Guid>>(newExpression).Compile()());
                 }
+                else if (newExpression.Type == typeof(Guid?))
+                {
+                    expression = WrappedConstant(Expression.Lambda<Func<Guid?>>(newExpression).Compile()());
+                }
                 else if (newExpression.Type == typeof(DateTime))
                 {
                     expression = WrappedConstant(Expression.Lambda<Func<DateTime>>(newExpression).Compile()());
+                }
+                else if (newExpression.Type == typeof(DateTime?))
+                {
+                    expression = WrappedConstant(Expression.Lambda<Func<DateTime?>>(newExpression).Compile()());
                 }
                 else if (newExpression.Type == typeof(DateTimeOffset))
                 {
                     expression = WrappedConstant(Expression.Lambda<Func<DateTimeOffset>>(newExpression).Compile()());
                 }
+                else if (newExpression.Type == typeof(DateTimeOffset?))
+                {
+                    expression = WrappedConstant(Expression.Lambda<Func<DateTimeOffset?>>(newExpression).Compile()());
+                }
                 else if (newExpression.Type == typeof(TimeSpan))
                 {
                     expression = WrappedConstant(Expression.Lambda<Func<TimeSpan>>(newExpression).Compile()());
+                }
+                else if (newExpression.Type == typeof(TimeSpan?))
+                {
+                    expression = WrappedConstant(Expression.Lambda<Func<TimeSpan?>>(newExpression).Compile()());
                 }
             }
         }

--- a/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
@@ -737,6 +737,8 @@ namespace System.Linq.Dynamic.Core.Parser
         Expression ParsePrimary()
         {
             Expression expr = ParsePrimaryStart();
+            _expressionHelper.WrapConstantExpression(ref expr);
+
             while (true)
             {
                 if (_textParser.CurrentToken.Id == TokenId.Dot)

--- a/test/EntityFramework.DynamicLinq.Tests.net452/EntityFramework.DynamicLinq.Tests.net452.csproj
+++ b/test/EntityFramework.DynamicLinq.Tests.net452/EntityFramework.DynamicLinq.Tests.net452.csproj
@@ -263,6 +263,9 @@
     <Compile Include="..\System.Linq.Dynamic.Core.Tests\Helpers\TestEnum.cs">
       <Link>Helpers\TestEnum.cs</Link>
     </Compile>
+    <Compile Include="..\System.Linq.Dynamic.Core.Tests\TestHelpers\ExpressionString.cs">
+      <Link>TestHelpers\ExpressionString.cs</Link>
+    </Compile>
     <Compile Include="..\System.Linq.Dynamic.Core.Tests\OperatorTests.cs">
       <Link>OperatorTests.cs</Link>
     </Compile>

--- a/test/System.Linq.Dynamic.Core.Tests/DynamicExpressionParserTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/DynamicExpressionParserTests.cs
@@ -252,6 +252,25 @@ namespace System.Linq.Dynamic.Core.Tests
         }
 
         [Fact]
+        public void DynamicExpressionParser_ParseLambda_UseParameterizedNamesInDynamicQuery_false()
+        {
+            // Assign
+            var config = new ParsingConfig
+            {
+                UseParameterizedNamesInDynamicQuery = false
+            };
+
+            // Act
+            var expression = DynamicExpressionParser.ParseLambda<string, bool>(config, true, "s => s == \"x\"");
+
+            // Assert
+            dynamic constantExpression = (ConstantExpression)(expression.Body as BinaryExpression).Right;
+            string value = constantExpression.Value;
+
+            Check.That(value).IsEqualTo("x");
+        }
+
+        [Fact]
         public void DynamicExpressionParser_ParseLambda_UseParameterizedNamesInDynamicQuery_true()
         {
             // Assign
@@ -261,16 +280,43 @@ namespace System.Linq.Dynamic.Core.Tests
             };
 
             // Act
-            var expression = DynamicExpressionParser.ParseLambda<string, bool>(config, true, "s => s == \"x\"");
+            var expression = DynamicExpressionParser.ParseLambda<Person, bool>(config, false, "Id = 42");
+            string expressionAsString = expression.ToString();
 
             // Assert
+            Check.That(expressionAsString).IsEqualTo("Param_0 => (Param_0.Id == value(System.Linq.Dynamic.Core.Parser.WrappedValue`1[System.Int32]).Value)");
+
             dynamic constantExpression = ((MemberExpression)(expression.Body as BinaryExpression).Right).Expression as ConstantExpression;
             dynamic wrappedObj = constantExpression.Value;
 
             var propertyInfo = wrappedObj.GetType().GetProperty("Value", BindingFlags.Instance | BindingFlags.Public);
-            string value = propertyInfo.GetValue(wrappedObj) as string;
+            int value = (int) propertyInfo.GetValue(wrappedObj);
 
-            Check.That(value).IsEqualTo("x");
+            Check.That(value).IsEqualTo(42);
+        }
+
+        [Fact]
+        public void DynamicExpressionParser_ParseLambda_UseParameterizedNamesInDynamicQuery_ForNullableProperty_true()
+        {
+            // Assign
+            var config = new ParsingConfig
+            {
+                UseParameterizedNamesInDynamicQuery = true
+            };
+
+            // Act
+            var expression = DynamicExpressionParser.ParseLambda<Person, bool>(config, false, "NullableId = 42");
+            string expressionAsString = expression.ToString();
+
+            // Assert
+            Check.That(expressionAsString).IsEqualTo("Param_0 => (Param_0.NullableId == value(System.Linq.Dynamic.Core.Parser.WrappedValue`1[System.Nullable`1[System.Int32]]).Value)");
+            dynamic constantExpression = ((MemberExpression)(expression.Body as BinaryExpression).Right).Expression as ConstantExpression;
+            dynamic wrappedObj = constantExpression.Value;
+
+            var propertyInfo = wrappedObj.GetType().GetProperty("Value", BindingFlags.Instance | BindingFlags.Public);
+            int? value = (int?) propertyInfo.GetValue(wrappedObj);
+
+            Check.That(value).IsEqualTo(42);
         }
 
         [Theory]
@@ -296,25 +342,6 @@ namespace System.Linq.Dynamic.Core.Tests
             Check.That(result).IsNotNull();
             Check.That(result).HasSize(expected.Count);
             Check.That(result.ToArray()[0]).Equals(expected[0]);
-        }
-
-        [Fact]
-        public void DynamicExpressionParser_ParseLambda_UseParameterizedNamesInDynamicQuery_false()
-        {
-            // Assign
-            var config = new ParsingConfig
-            {
-                UseParameterizedNamesInDynamicQuery = false
-            };
-
-            // Act
-            var expression = DynamicExpressionParser.ParseLambda<string, bool>(config, true, "s => s == \"x\"");
-
-            // Assert
-            dynamic constantExpression = (ConstantExpression)(expression.Body as BinaryExpression).Right;
-            string value = constantExpression.Value;
-
-            Check.That(value).IsEqualTo("x");
         }
 
         [Fact]

--- a/test/System.Linq.Dynamic.Core.Tests/Helpers/Models/SimpleValuesModel.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/Helpers/Models/SimpleValuesModel.cs
@@ -10,5 +10,9 @@ namespace System.Linq.Dynamic.Core.Tests.Helpers.Models
         public decimal DecimalValue { get; set; }
 
         public double DoubleValue { get; set; }
+
+        public int? NullableIntValue { get; set; }
+
+        public double? NullableDoubleValue { get; set; }
     }
 }

--- a/test/System.Linq.Dynamic.Core.Tests/Parser/ExpressionHelperTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/Parser/ExpressionHelperTests.cs
@@ -36,6 +36,27 @@ namespace System.Linq.Dynamic.Core.Tests.Parser
         }
 
         [Fact]
+        public void ExpressionHelper_WrapNullableConstantExpression_false()
+        {
+            // Assign
+            var config = new ParsingConfig
+            {
+                UseParameterizedNamesInDynamicQuery = false
+            };
+            var expressionHelper = new ExpressionHelper(config);
+
+            int? value = 42;
+            Expression expression = Expression.Constant(value);
+
+            // Act
+            expressionHelper.WrapConstantExpression(ref expression);
+
+            // Assert
+            Check.That(expression).IsInstanceOf<ConstantExpression>();
+            Check.That(expression.ToString()).Equals("42");
+        }
+
+        [Fact]
         public void ExpressionHelper_WrapConstantExpression_true()
         {
             // Assign
@@ -55,6 +76,28 @@ namespace System.Linq.Dynamic.Core.Tests.Parser
             // Assert
             Check.That(expression.GetType().FullName).Equals("System.Linq.Expressions.PropertyExpression");
             Check.That(expression.ToString()).Equals("value(System.Linq.Dynamic.Core.Parser.WrappedValue`1[System.String]).Value");
+        }
+
+        [Fact]
+        public void ExpressionHelper_WrapNullableConstantExpression_true()
+        {
+            // Assign
+            var config = new ParsingConfig
+            {
+                UseParameterizedNamesInDynamicQuery = true
+            };
+            var expressionHelper = new ExpressionHelper(config);
+
+            int? value = 42;
+            Expression expression = Expression.Constant(value);
+
+            // Act
+            expressionHelper.WrapConstantExpression(ref expression);
+            expressionHelper.WrapConstantExpression(ref expression);
+
+            // Assert
+            Check.That(expression.GetType().FullName).Equals("System.Linq.Expressions.PropertyExpression");
+            Check.That(expression.ToString()).Equals("value(System.Linq.Dynamic.Core.Parser.WrappedValue`1[System.Int32]).Value");
         }
 
         [Fact]

--- a/test/System.Linq.Dynamic.Core.Tests/TestHelpers/ExpressionString.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/TestHelpers/ExpressionString.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Linq.Dynamic.Core.Tests.TestHelpers
+{
+    public static class ExpressionString
+    {
+        public static string NullableConversion(string convertedExpr)
+        {
+#if NET452
+            return $"Convert({convertedExpr})";
+#else
+            return $"Convert({convertedExpr}, Nullable`1)";
+#endif
+        }
+    }
+}


### PR DESCRIPTION
Builds on https://github.com/zzzprojects/System.Linq.Dynamic.Core/issues/331 - added wrapping of constants as soon as they're parsed to avoid cases where they can slip through the cracks.