### PR TITLE
Add support for IQueryable.Min and .Max

### DIFF
--- a/src/System.Linq.Dynamic.Core/DynamicQueryableExtensions.cs
+++ b/src/System.Linq.Dynamic.Core/DynamicQueryableExtensions.cs
@@ -1294,6 +1294,152 @@ namespace System.Linq.Dynamic.Core
         }
         #endregion LongCount
 
+        #region Max
+        private static readonly MethodInfo _max = GetMethod(nameof(Queryable.Max));
+
+        /// <summary>
+        /// Computes the max element of a sequence.
+        /// </summary>
+        /// <param name="source">A sequence of values to calculate find the max for.</param>
+        /// <example>
+        /// <code language="cs">
+        /// IQueryable queryable = employees.AsQueryable();
+        /// var result1 = queryable.Max();
+        /// var result2 = queryable.Select("Roles.Max()");
+        /// </code>
+        /// </example>
+        /// <returns>The max element in the sequence.</returns>
+        [PublicAPI]
+        public static object Max([NotNull] this IQueryable source)
+        {
+            Check.NotNull(source, nameof(source));
+
+            return Execute(_max, source);
+        }
+
+        private static readonly MethodInfo _maxPredicate = GetMethod(nameof(Queryable.Max), 1);
+
+        /// <summary>
+        /// Computes the max element of a sequence.
+        /// </summary>
+        /// <param name="source">A sequence of values to calculate find the max for.</param>
+        /// <param name="config">The <see cref="ParsingConfig"/>.</param>
+        /// <param name="predicate">A function to test each element for a condition.</param>
+        /// <param name="args">An object array that contains zero or more objects to insert into the predicate as parameters. Similar to the way String.Format formats strings.</param>
+        /// <example>
+        /// <code language="cs">
+        /// IQueryable queryable = employees.AsQueryable();
+        /// var result = queryable.Max("Income");
+        /// </code>
+        /// </example>
+        /// <returns>The max element in the sequence.</returns>
+        [PublicAPI]
+        public static object Max([NotNull] this IQueryable source, [NotNull] ParsingConfig config, [NotNull] string predicate, params object[] args)
+        {
+            Check.NotNull(source, nameof(source));
+            Check.NotNull(config, nameof(config));
+            Check.NotEmpty(predicate, nameof(predicate));
+
+            bool createParameterCtor = SupportsLinqToObjects(config, source);
+            LambdaExpression lambda = DynamicExpressionParser.ParseLambda(config, createParameterCtor, source.ElementType, typeof(object), predicate, args);
+
+            return Execute(_maxPredicate, source, lambda);
+        }
+
+        /// <inheritdoc cref="Max(IQueryable, ParsingConfig, string, object[])"/>
+        [PublicAPI]
+        public static object Max([NotNull] this IQueryable source, [NotNull] string predicate, [CanBeNull] params object[] args)
+        {
+            return Max(source, ParsingConfig.Default, predicate, args);
+        }
+
+        /// <summary>
+        /// Computes the max element of a sequence.
+        /// </summary>
+        /// <param name="source">A sequence of values to calculate find the max for.</param>
+        /// <param name="lambda">A Lambda Expression.</param>
+        /// <returns>The max element in the sequence.</returns>
+        [PublicAPI]
+        public static object Max([NotNull] this IQueryable source, [NotNull] LambdaExpression lambda)
+        {
+            Check.NotNull(source, nameof(source));
+            return Execute(_maxPredicate, source, lambda);
+        }
+        #endregion Max
+
+        #region Min
+        private static readonly MethodInfo _min = GetMethod(nameof(Queryable.Min));
+
+        /// <summary>
+        /// Computes the min element of a sequence.
+        /// </summary>
+        /// <param name="source">A sequence of values to calculate find the min for.</param>
+        /// <example>
+        /// <code language="cs">
+        /// IQueryable queryable = employees.AsQueryable();
+        /// var result1 = queryable.Min();
+        /// var result2 = queryable.Select("Roles.Min()");
+        /// </code>
+        /// </example>
+        /// <returns>The min element in the sequence.</returns>
+        [PublicAPI]
+        public static object Min([NotNull] this IQueryable source)
+        {
+            Check.NotNull(source, nameof(source));
+
+            return Execute(_min, source);
+        }
+
+        private static readonly MethodInfo _minPredicate = GetMethod(nameof(Queryable.Min), 1);
+
+        /// <summary>
+        /// Computes the min element of a sequence.
+        /// </summary>
+        /// <param name="source">A sequence of values to calculate find the min for.</param>
+        /// <param name="config">The <see cref="ParsingConfig"/>.</param>
+        /// <param name="predicate">A function to test each element for a condition.</param>
+        /// <param name="args">An object array that contains zero or more objects to insert into the predicate as parameters. Similar to the way String.Format formats strings.</param>
+        /// <example>
+        /// <code language="cs">
+        /// IQueryable queryable = employees.AsQueryable();
+        /// var result = queryable.Min("Income");
+        /// </code>
+        /// </example>
+        /// <returns>The min element in the sequence.</returns>
+        [PublicAPI]
+        public static object Min([NotNull] this IQueryable source, [NotNull] ParsingConfig config, [NotNull] string predicate, params object[] args)
+        {
+            Check.NotNull(source, nameof(source));
+            Check.NotNull(config, nameof(config));
+            Check.NotEmpty(predicate, nameof(predicate));
+
+            bool createParameterCtor = SupportsLinqToObjects(config, source);
+            LambdaExpression lambda = DynamicExpressionParser.ParseLambda(config, createParameterCtor, source.ElementType, typeof(object), predicate, args);
+
+            return Execute(_minPredicate, source, lambda);
+        }
+
+        /// <inheritdoc cref="Min(IQueryable, ParsingConfig, string, object[])"/>
+        [PublicAPI]
+        public static object Min([NotNull] this IQueryable source, [NotNull] string predicate, [CanBeNull] params object[] args)
+        {
+            return Min(source, ParsingConfig.Default, predicate, args);
+        }
+
+        /// <summary>
+        /// Computes the min element of a sequence.
+        /// </summary>
+        /// <param name="source">A sequence of values to calculate find the min for.</param>
+        /// <param name="lambda">A Lambda Expression.</param>
+        /// <returns>The min element in the sequence.</returns>
+        [PublicAPI]
+        public static object Min([NotNull] this IQueryable source, [NotNull] LambdaExpression lambda)
+        {
+            Check.NotNull(source, nameof(source));
+            return Execute(_minPredicate, source, lambda);
+        }
+        #endregion Min
+
         #region OfType
         private static readonly MethodInfo _ofType = GetGenericMethod(nameof(Queryable.OfType));
 

--- a/test/System.Linq.Dynamic.Core.Tests/QueryableTests.Max.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/QueryableTests.Max.cs
@@ -1,0 +1,36 @@
+﻿using System.Linq.Dynamic.Core.Tests.Helpers.Models;
+using Xunit;
+
+namespace System.Linq.Dynamic.Core.Tests
+{
+    public partial class QueryableTests
+    {
+        [Fact]
+        public void Max()
+        {
+            // Arrange
+            var incomes = User.GenerateSampleModels(100).Select(u => u.Income);
+
+            // Act
+            var expected = incomes.Max();
+            var actual = incomes.AsQueryable().Max();
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Max_Selector()
+        {
+            // Arrange
+            var users = User.GenerateSampleModels(100);
+
+            // Act
+            var expected = users.Max(u => u.Income);
+            var result = users.AsQueryable().Max("Income");
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/test/System.Linq.Dynamic.Core.Tests/QueryableTests.Min.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/QueryableTests.Min.cs
@@ -1,0 +1,36 @@
+﻿using System.Linq.Dynamic.Core.Tests.Helpers.Models;
+using Xunit;
+
+namespace System.Linq.Dynamic.Core.Tests
+{
+    public partial class QueryableTests
+    {
+        [Fact]
+        public void Min()
+        {
+            // Arrange
+            var incomes = User.GenerateSampleModels(100).Select(u => u.Income);
+
+            // Act
+            var expected = incomes.Min();
+            var actual = incomes.AsQueryable().Min();
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Min_Selector()
+        {
+            // Arrange
+            var users = User.GenerateSampleModels(100);
+
+            // Act
+            var expected = users.Min(u => u.Income);
+            var result = users.AsQueryable().Min("Income");
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}


### PR DESCRIPTION
Min and Max extension methods for IQueryable were not available.