### PR TITLE
support for generic (static) methods, thus also support for extension…

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.DynamicLinq.EFCore6/Microsoft.EntityFrameworkCore.DynamicLinq.EFCore6.csproj
+++ b/src/Microsoft.EntityFrameworkCore.DynamicLinq.EFCore6/Microsoft.EntityFrameworkCore.DynamicLinq.EFCore6.csproj
@@ -3,7 +3,7 @@
 
     <PropertyGroup>
         <!--<Version>6.2.$(PatchVersion)</Version>-->
-        <Version>6.0.0-preview.3.21201.2</Version>
+        <Version>6.0.0-preview.4.21253.1</Version>
         <Description>Dynamic Linq extensions for Microsoft.EntityFrameworkCore which adds Async support</Description>
         <AssemblyTitle>Microsoft.EntityFrameworkCore.DynamicLinq</AssemblyTitle>
         <Authors>ZZZ Projects;Stef Heyenrath</Authors>
@@ -55,6 +55,6 @@
 
     <ItemGroup>
         <PackageReference Include="JetBrains.Annotations" Version="2021.1.0" PrivateAssets="All" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0-preview.3.21201.2" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0-preview.4.21253.1" />
     </ItemGroup>
 </Project>

--- a/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
@@ -1704,9 +1704,12 @@ namespace System.Linq.Dynamic.Core.Parser
                             throw ParseError(errorPos, Res.MethodsAreInaccessible, TypeHelper.GetTypeName(method.DeclaringType));
                         }
 
-                        if (expression == null)
+                        if (method.IsGenericMethod)
                         {
-                            return Expression.Call(null, method, args);
+                            var genericParameters = method.GetParameters().Where(p => p.ParameterType.IsGenericParameter);
+                            var typeArguments = genericParameters.Select(a => args[a.Position].Type);
+                            var constructedMethod = method.MakeGenericMethod(typeArguments.ToArray());
+                            return Expression.Call(expression, constructedMethod, args);
                         }
                         else
                         {

--- a/src/System.Linq.Dynamic.Core/Parser/ExpressionPromoter.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/ExpressionPromoter.cs
@@ -22,7 +22,7 @@ namespace System.Linq.Dynamic.Core.Parser
         /// <inheritdoc cref="IExpressionPromoter.Promote(Expression, Type, bool, bool)"/>
         public virtual Expression Promote(Expression expr, Type type, bool exact, bool convertExpr)
         {
-            if (expr.Type == type)
+            if (expr.Type == type || type.IsGenericParameter)
             {
                 return expr;
             }

--- a/src/System.Linq.Dynamic.Core/Parser/SupportedMethods/MethodFinder.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/SupportedMethods/MethodFinder.cs
@@ -58,7 +58,7 @@ namespace System.Linq.Dynamic.Core.Parser.SupportedMethods
                 {
                     if (_parsingConfig.CustomTypeProvider.GetExtensionMethods().TryGetValue(t, out var extensionMethodsOfType))
                     {
-                        methods.AddRange(extensionMethodsOfType.Where(m => m.Name.Equals(methodName, StringComparison.OrdinalIgnoreCase) && !m.IsGenericMethod));
+                        methods.AddRange(extensionMethodsOfType.Where(m => m.Name.Equals(methodName, StringComparison.OrdinalIgnoreCase)));
                     }
                 }
 

--- a/test/System.Linq.Dynamic.Core.Tests/DynamicExpressionParserTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/DynamicExpressionParserTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq.Dynamic.Core.CustomTypeProviders;
 using System.Linq.Dynamic.Core.Exceptions;
 using System.Linq.Dynamic.Core.Tests.Helpers.Models;
@@ -1070,7 +1070,7 @@ namespace System.Linq.Dynamic.Core.Tests
 
             // Assert
             Assert.Equal(anotherId, result);
-        }        
+        }
 
         [Theory]
         [InlineData("c => c.Age == 8", "c => (c.Age == 8)")]
@@ -1239,7 +1239,7 @@ namespace System.Linq.Dynamic.Core.Tests
 
             var @delegate = expression.Compile();
 
-            var result = (bool) @delegate.DynamicInvoke("This is a test  ");
+            var result = (bool)@delegate.DynamicInvoke("This is a test  ");
 
             // Assert
             result.Should().BeTrue();
@@ -1257,6 +1257,37 @@ namespace System.Linq.Dynamic.Core.Tests
 
             // Assert
             result.Should().BeTrue();
+        }
+
+        public class DefaultDynamicLinqCustomTypeProviderForGenericExtensionMethod : CustomTypeProviders.DefaultDynamicLinqCustomTypeProvider
+        {
+            public override HashSet<Type> GetCustomTypes() => new HashSet<Type>(base.GetCustomTypes()) { typeof(Methods), typeof(MethodsItemExtension) };
+        }
+
+        [Fact]
+        public void DynamicExpressionParser_ParseLambda_GenericExtensionMethod()
+        {
+            // Arrange
+            var testList = User.GenerateSampleModels(51);
+            var config = new ParsingConfig()
+            {
+                CustomTypeProvider = new DefaultDynamicLinqCustomTypeProviderForGenericExtensionMethod()
+            };
+
+            // Act
+            string query = "x => MethodsItemExtension.Functions.EfCoreCollate(x.UserName, \"tlh-KX\")==\"User4\" || MethodsItemExtension.Functions.EfCoreCollate(x.UserName, \"tlh-KX\")==\"User2\"";
+            var expression = DynamicExpressionParser.ParseLambda<User, bool>(config, false, query);
+            var del = expression.Compile();
+
+            var result = Enumerable.Where(testList, del);
+
+
+            var expected = testList.Where(x => new string[] { "User4", "User2" }.Contains(x.UserName)).ToList();
+
+            // Assert
+            Check.That(result).IsNotNull();
+            Check.That(result).HasSize(expected.Count);
+            Check.That(result).Equals(expected);
         }
     }
 }

--- a/test/System.Linq.Dynamic.Core.Tests/Helpers/Models/Methods.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/Helpers/Models/Methods.cs
@@ -1,4 +1,4 @@
-﻿namespace System.Linq.Dynamic.Core.Tests.Helpers.Models
+namespace System.Linq.Dynamic.Core.Tests.Helpers.Models
 {
     public class Methods
     {
@@ -22,5 +22,17 @@
         {
             public int Value { get; set; }
         }
+
+        public static bool StaticGenericMethod<T>(T value) => value is Item item && item.Value == 1;
+        public bool GenericMethod<T>(T value) => value is Item item && item.Value == 1;
+
+    }
+
+    public static class MethodsItemExtension
+    {
+        public class DummyFunctions { }
+        public static DummyFunctions Functions => new DummyFunctions();
+
+        public static T EfCoreCollate<T>(this DummyFunctions _, T value, string collation) => value;
     }
 }


### PR DESCRIPTION
this PR provides support for generic methods (as (among others) requested in #386 ), and thus also for generic extension methods.
An actual use case for this whould be the, in EF Core 5.0, introduced  "Collate" extension method, wich has a generic signatue:

```c#
// https://github.com/dotnet/efcore/blob/v5.0.7/src/EFCore.Relational/Extensions/RelationalDbFunctionsExtensions.cs 
public static TProperty Collate<TProperty>(
           [NotNull] this DbFunctions _,
           [NotNull] TProperty operand,
           [NotNull] [NotParameterized] string collation)
```

Also contains additional unit tests

