### PR TITLE
Parse in operator before comparisons

### DIFF
--- a/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
@@ -283,7 +283,7 @@ namespace System.Linq.Dynamic.Core.Parser
             {
                 Token op = _textParser.CurrentToken;
                 _textParser.NextToken();
-                Expression right = ParseComparisonOperator();
+                Expression right = ParseIn();
                 CheckAndPromoteOperands(typeof(ILogicalSignatures), op.Id, op.Text, ref left, ref right, op.Pos);
                 left = Expression.AndAlso(left, right);
             }

--- a/test/System.Linq.Dynamic.Core.Tests/EntitiesTests.In.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/EntitiesTests.In.cs
@@ -1,0 +1,34 @@
+﻿#if EFCORE
+using Microsoft.EntityFrameworkCore;
+#else
+
+using System.Data.Entity;
+
+#endif
+
+using Xunit;
+
+namespace System.Linq.Dynamic.Core.Tests
+{
+    public partial class EntitiesTests : IDisposable
+    {
+        /// <summary>
+        /// Test for https://github.com/zzzprojects/System.Linq.Dynamic.Core/pull/524
+        /// </summary>
+        [Fact]
+        public void Entities_Where_In_And()
+        {
+            // Arrange
+            PopulateTestData();
+
+            var expected = _context.Blogs.Include(b => b.Posts).Where(b => new[] { 1, 3, 5 }.Contains(b.BlogId) && new [] { "Blog3", "Blog4" }.Contains(b.Name)).ToArray();
+
+            // Act
+            var test = _context.Blogs.Include(b => b.Posts).Where(@"BlogId in (1, 3, 5) and Name in (""Blog3"", ""Blog4"")").ToArray();
+
+            // Assert
+            Assert.NotEmpty(test);
+            Assert.Equal(expected, test);
+        }
+    }
+}

--- a/test/System.Linq.Dynamic.Core.Tests/Parser/ExpressionParserTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/Parser/ExpressionParserTests.cs
@@ -93,6 +93,20 @@ namespace System.Linq.Dynamic.Core.Tests.Parser
             Check.That(parsedExpression).Equals(result);
         }
 
+        [Fact]
+        public void Parse_ParseMultipleInOperators()
+        {
+            // Arrange
+            ParameterExpression[] parameters = { ParameterExpressionHelper.CreateParameterExpression(typeof(Company), "x") };
+            var sut = new ExpressionParser(parameters, "MainCompanyId in (1, 2) and Name in (\"A\", \"B\")", null, null);
+
+            // Act
+            var parsedExpression = sut.Parse(null).ToString();
+
+            // Assert
+            Check.That(parsedExpression).Equals("(((x.MainCompanyId == 1) OrElse (x.MainCompanyId == 2)) AndAlso ((x.Name == \"A\") OrElse (x.Name == \"B\")))");
+        }
+
         [Theory]
         [InlineData("string(\"\")", "")]
         [InlineData("string(\"a\")", "a")]


### PR DESCRIPTION
Hi,

Inspired by SQL `where` clauses, I'm used to the `in` operator having precedence over others like `and` and `or`.

For example, I'm used to `MainCompanyId in (1, 2) and Name in ("A")` to be parsed as `(((x.MainCompanyId == 1) OrElse (x.MainCompanyId == 2)) AndAlso (x.Name == "A"))`. 

I think currently the parser attempts to parse it to something like `((((x.MainCompanyId == 1) OrElse (x.MainCompanyId == 2)) AndAlso x.Name) == "A")`, which is invalid syntax.

A current workaround is to add additional parentheses and write the clause as `(MainCompanyId in (1, 2)) and (Name in ("A"))`. This parses successfully, but it feels quite verbose to me.

This PR fixes the issue by first parsing for `in`s before comparisons. It was a simple fix and I'm almost surprised that it didn't break any existing tests (as far as I can see). I added a unit test for this PR's change.

Hope I didn't miss anything and that you agree with change in operator precedence in principle.