### PR TITLE
Allow assembly to be collected

### DIFF
--- a/src/System.Linq.Dynamic.Core/DynamicClassFactory.cs
+++ b/src/System.Linq.Dynamic.Core/DynamicClassFactory.cs
@@ -72,7 +72,7 @@ namespace System.Linq.Dynamic.Core
         static DynamicClassFactory()
         {
             var assemblyName = new AssemblyName(DynamicAssemblyName);
-            var assemblyBuilder = AssemblyBuilderFactory.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+            var assemblyBuilder = AssemblyBuilderFactory.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.RunAndCollect);
 
             ModuleBuilder = assemblyBuilder.DefineDynamicModule(DynamicModuleName);
         }


### PR DESCRIPTION
Running this library from a collectable AssemblyLoadContext produces the following exception:

System.NotSupportedException: 'A non-collectible assembly may not reference a collectible assembly.'