### PR TITLE
Fixed: Parenthesis around an "In" expression raise an exception

### DIFF
--- a/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
@@ -340,6 +340,9 @@ namespace System.Linq.Dynamic.Core.Parser
                             throw ParseError(op.Pos, Res.CloseParenOrCommaExpected);
                         }
                     }
+
+                    // Since this started with an open paren, make sure to move off the close
+                    _textParser.NextToken();
                 }
                 else if (_textParser.CurrentToken.Id == TokenId.Identifier) // a single argument
                 {
@@ -368,8 +371,6 @@ namespace System.Linq.Dynamic.Core.Parser
                 {
                     throw ParseError(op.Pos, Res.OpenParenOrIdentifierExpected);
                 }
-
-                _textParser.NextToken();
             }
 
             return accumulate;

--- a/test/System.Linq.Dynamic.Core.Tests/Parser/ExpressionParserTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/Parser/ExpressionParserTests.cs
@@ -139,6 +139,20 @@ namespace System.Linq.Dynamic.Core.Tests.Parser
             Check.That(parsedExpression).Equals("(((x.MainCompanyId == 1) OrElse (x.MainCompanyId == 2)) AndAlso ((x.Name == \"A\") OrElse (x.Name == \"B\")))");
         }
 
+        [Fact]
+        public void Parse_ParseInWrappedInParenthesis()
+        {
+            // Arrange
+            ParameterExpression[] parameters = { ParameterExpressionHelper.CreateParameterExpression(typeof(Company), "x") };
+            var sut = new ExpressionParser(parameters, "(MainCompanyId in @0)", new object[] { new long?[] { 1, 2 } }, null);
+
+            // Act
+            var parsedExpression = sut.Parse(null).ToString();
+
+            // Assert
+            Check.That(parsedExpression).Equals("value(System.Nullable`1[System.Int64][]).Contains(x.MainCompanyId)");
+        }
+
         [Theory]
         [InlineData("string(\"\")", "")]
         [InlineData("string(\"a\")", "a")]


### PR DESCRIPTION
Fixes: #586

Parser is greedy eating the next token inside an In expression when the expression is an Identifier.
This worked correctly when the expression is: `x in (1, 2)` but fails when `(x in @0)`.

Moved the token read into the Paren code branch which fixes the problem.