### PR TITLE
Fix MethodFinder to return topmost implementation of the virtual method

### DIFF
--- a/src/System.Linq.Dynamic.Core/Parser/SupportedMethods/MethodFinder.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/SupportedMethods/MethodFinder.cs
@@ -105,7 +105,7 @@ namespace System.Linq.Dynamic.Core.Parser.SupportedMethods
             if (applicable.Length == 1)
             {
                 MethodData md = applicable[0];
-                method = md.MethodBase;
+                method = ((MethodInfo)md.MethodBase).GetBaseDefinition();
                 args = md.Args;
             }
             else

--- a/test/System.Linq.Dynamic.Core.Tests/Parser/MethodFinderTest.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/Parser/MethodFinderTest.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Linq.Expressions;
+using static System.Console;
+using static System.Linq.Expressions.Expression;
+using System.Linq.Dynamic.Core.Parser;
+using System.Linq.Dynamic.Core;
+using Xunit;
+
+namespace System.Linq.Dynamic.Core.Tests.Parser
+{
+    public class MethodFinderTest
+    {
+        [Fact]
+        public void MethodsOfDynamicLinqAndSystemLinqShouldBeEqual()
+        {
+            Expression<Func<int?, string?>> expr = x => x.ToString();
+            
+            var selector = "ToString()";
+            var prm = Parameter(typeof(int?));
+            var parser = new ExpressionParser(new[] { prm }, selector, new object[] { }, ParsingConfig.Default);
+            var expr1 = parser.Parse(null);
+            
+            Assert.Equal(((MethodCallExpression)expr.Body).Method.DeclaringType, ((MethodCallExpression)expr1).Method.DeclaringType);
+        }
+    }
+}


### PR DESCRIPTION
uses the topmost implementation of the virtual method