### PR TITLE
Init field only on first execution

### DIFF
--- a/src/System.Linq.Dynamic.Core/DynamicClass.cs
+++ b/src/System.Linq.Dynamic.Core/DynamicClass.cs
@@ -18,24 +18,28 @@ namespace System.Linq.Dynamic.Core;
 /// </summary>
 public abstract class DynamicClass : DynamicObject
 {
-    private readonly Dictionary<string, object?> _propertiesDictionary = new();
+    private Dictionary<string, object?>? _propertiesDictionary = null;
 
     private Dictionary<string, object?> Properties
     {
         get
         {
-            foreach (PropertyInfo pi in GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            if (_propertiesDictionary == null)
             {
-                int parameters = pi.GetIndexParameters().Length;
-                if (parameters > 0)
+                _propertiesDictionary = new();
+                foreach (PropertyInfo pi in GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
                 {
-                    // The property is an indexer, skip this.
-                    continue;
-                }
+                    int parameters = pi.GetIndexParameters().Length;
+                    if (parameters > 0)
+                    {
+                        // The property is an indexer, skip this.
+                        continue;
+                    }
 
-                _propertiesDictionary.Add(pi.Name, pi.GetValue(this, null));
+                    _propertiesDictionary.Add(pi.Name, pi.GetValue(this, null));
+                }
             }
-            
+
             return _propertiesDictionary;
         }
     }

--- a/test/System.Linq.Dynamic.Core.Tests.Net6/DynamicClassTest.cs
+++ b/test/System.Linq.Dynamic.Core.Tests.Net6/DynamicClassTest.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using Xunit;
+
+namespace System.Linq.Dynamic.Core.Tests
+{
+    public class DynamicClassTest
+    {
+        [Fact]
+        public void GetPropertiesWorks()
+        {
+            // Arrange
+            var range = new List<object> 
+            { 
+                new { FieldName = "TestFieldName", Value = 3.14159 }
+            };
+
+            // Act
+            var rangeResult = range.AsQueryable().Select("new(FieldName as FieldName)").ToDynamicList();
+            var item = rangeResult.FirstOrDefault();
+
+            var call = () => item.GetDynamicMemberNames();
+            call.Should().NotThrow();
+            call.Should().NotThrow();
+        }
+    }
+}


### PR DESCRIPTION
The current getter throws if called more than once, as the dictionary has already been set up. 