### PR TITLE
Add Json support: check return types of method

### DIFF
--- a/src/System.Linq.Dynamic.Core.SystemTextJson/SystemTextJsonExtensions.cs
+++ b/src/System.Linq.Dynamic.Core.SystemTextJson/SystemTextJsonExtensions.cs
@@ -14,6 +14,7 @@ namespace System.Linq.Dynamic.Core.SystemTextJson;
 /// </summary>
 public static class SystemTextJsonExtensions
 {
+    private const string sequenceEmpty = "Sequence contains no elements";
     #region Aggregate
     /// <summary>
     /// Dynamically runs an aggregate function on the <see cref="JsonDocument"/>>.
@@ -338,7 +339,7 @@ public static class SystemTextJsonExtensions
         Check.NotNull(source);
 
         var queryable = ToQueryable(source);
-        return ToJsonElement(queryable.First());
+        return ToJsonElement(queryable.First()) ?? throw new InvalidOperationException(sequenceEmpty);
     }
 
     /// <summary>
@@ -355,7 +356,7 @@ public static class SystemTextJsonExtensions
         Check.NotNull(config);
 
         var queryable = ToQueryable(source, config);
-        return ToJsonElement(queryable.First(config, predicate, args));
+        return ToJsonElement(queryable.First(config, predicate, args)) ?? throw new InvalidOperationException(sequenceEmpty);
     }
 
     /// <summary>
@@ -381,7 +382,7 @@ public static class SystemTextJsonExtensions
         Check.NotNull(source);
 
         var queryable = ToQueryable(source);
-        return ToJsonElement(queryable.First(lambda));
+        return ToJsonElement(queryable.First(lambda)) ?? throw new InvalidOperationException(sequenceEmpty);
     }
     #endregion First
 
@@ -454,7 +455,7 @@ public static class SystemTextJsonExtensions
         Check.NotNull(source);
 
         var queryable = ToQueryable(source);
-        return ToJsonElement(queryable.Last());
+        return ToJsonElement(queryable.Last()) ?? throw new InvalidOperationException(sequenceEmpty);
     }
 
     /// <summary>
@@ -471,7 +472,7 @@ public static class SystemTextJsonExtensions
         Check.NotNull(config);
 
         var queryable = ToQueryable(source, config);
-        return ToJsonElement(queryable.Last(predicate, args));
+        return ToJsonElement(queryable.Last(predicate, args)) ?? throw new InvalidOperationException(sequenceEmpty);
     }
 
     /// <summary>
@@ -497,7 +498,7 @@ public static class SystemTextJsonExtensions
         Check.NotNull(source);
 
         var queryable = ToQueryable(source);
-        return ToJsonElement(queryable.Last(lambda));
+        return ToJsonElement(queryable.Last(lambda)) ?? throw new InvalidOperationException(sequenceEmpty);
     }
     #endregion Last
 
@@ -860,7 +861,7 @@ public static class SystemTextJsonExtensions
         Check.NotNull(source);
 
         var queryable = ToQueryable(source);
-        return ToJsonElement(queryable.Single());
+        return ToJsonElement(queryable.Single()) ?? throw new InvalidOperationException(sequenceEmpty);
     }
 
     /// <summary>
@@ -878,7 +879,7 @@ public static class SystemTextJsonExtensions
         Check.NotNull(config);
 
         var queryable = ToQueryable(source, config);
-        return ToJsonElement(queryable.Single(predicate, args));
+        return ToJsonElement(queryable.Single(predicate, args)) ?? throw new InvalidOperationException(sequenceEmpty);
     }
 
     /// <summary>
@@ -904,7 +905,7 @@ public static class SystemTextJsonExtensions
     public static JsonElement Single(this JsonDocument source, LambdaExpression lambda)
     {
         var queryable = ToQueryable(source);
-        return ToJsonElement(queryable.Single(lambda));
+        return ToJsonElement(queryable.Single(lambda)) ?? throw new InvalidOperationException(sequenceEmpty);
     }
     #endregion Single
 


### PR DESCRIPTION
Hi @StefH,

I fixed the single and first methods that accordingly to the [C# docs](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.first?view=net-8.0) should return an invalid operation with `Sequence contains no elements`.
