### PR TITLE
Incorrect Handling of Qualifiers in ConstantExpressionHelper

### DIFF
--- a/src/System.Linq.Dynamic.Core/Parser/NumberParser.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/NumberParser.cs
@@ -180,15 +180,15 @@ namespace System.Linq.Dynamic.Core.Parser
             {
                 case 'f':
                 case 'F':
-                    return ConstantExpressionHelper.CreateLiteral(ParseNumber(text, typeof(float))!, text);
+                    return _constantExpressionHelper.CreateLiteral(ParseNumber(text, typeof(float))!, text);
 
                 case 'm':
                 case 'M':
-                    return ConstantExpressionHelper.CreateLiteral(ParseNumber(text, typeof(decimal))!, text);
+                    return _constantExpressionHelper.CreateLiteral(ParseNumber(text, typeof(decimal))!, text);
 
                 case 'd':
                 case 'D':
-                    return ConstantExpressionHelper.CreateLiteral(ParseNumber(text, typeof(double))!, text);
+                    return _constantExpressionHelper.CreateLiteral(ParseNumber(text, typeof(double))!, text);
 
                 default:
                     return _constantExpressionHelper.CreateLiteral(ParseNumber(text, typeof(double))!, text);

--- a/src/System.Linq.Dynamic.Core/Parser/NumberParser.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/NumberParser.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using System.Linq.Dynamic.Core.Exceptions;
 using System.Linq.Dynamic.Core.Validation;
 using System.Linq.Expressions;
@@ -161,19 +161,34 @@ namespace System.Linq.Dynamic.Core.Parser
         /// </summary>
         public Expression ParseRealLiteral(string text, char qualifier, bool stripQualifier)
         {
+            if (stripQualifier)
+            {
+                var pos = text.Length - 1;
+                while (pos >= 0 && Qualifiers.Contains(text[pos]))
+                {
+                    pos--;
+                }
+
+                if (pos < text.Length - 1)
+                {
+                    qualifier = text[pos + 1];
+                    text = text.Substring(0, pos + 1);
+                }
+            }
+
             switch (qualifier)
             {
                 case 'f':
                 case 'F':
-                    return _constantExpressionHelper.CreateLiteral(ParseNumber(stripQualifier ? text.Substring(0, text.Length - 1) : text, typeof(float))!, text);
+                    return ConstantExpressionHelper.CreateLiteral(ParseNumber(text, typeof(float))!, text);
 
                 case 'm':
                 case 'M':
-                    return _constantExpressionHelper.CreateLiteral(ParseNumber(stripQualifier ? text.Substring(0, text.Length - 1) : text, typeof(decimal))!, text);
+                    return ConstantExpressionHelper.CreateLiteral(ParseNumber(text, typeof(decimal))!, text);
 
                 case 'd':
                 case 'D':
-                    return _constantExpressionHelper.CreateLiteral(ParseNumber(stripQualifier ? text.Substring(0, text.Length - 1) : text, typeof(double))!, text);
+                    return ConstantExpressionHelper.CreateLiteral(ParseNumber(text, typeof(double))!, text);
 
                 default:
                     return _constantExpressionHelper.CreateLiteral(ParseNumber(text, typeof(double))!, text);

--- a/test/System.Linq.Dynamic.Core.Tests/Parser/NumberParserTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/Parser/NumberParserTests.cs
@@ -15,15 +15,15 @@ namespace System.Linq.Dynamic.Core.Tests.Parser
         {
             return new object[][]
             {
-                new object[] { "de-DE", "1", 1m },
-                new object[] { "de-DE", "-42", -42m },
-                new object[] { "de-DE", "3,215", 3.215m },
-                new object[] { "de-DE", "3.215", 3215m },
+                new object[] {"de-DE", "1", 1m},
+                new object[] {"de-DE", "-42", -42m},
+                new object[] {"de-DE", "3,215", 3.215m},
+                new object[] {"de-DE", "3.215", 3215m},
 
-                new object[] { null, "1", 1m },
-                new object[] { null, "-42", -42m },
-                new object[] { null, "3,215", 3215m },
-                new object[] { null, "3.215", 3.215m }
+                new object[] {null, "1", 1m},
+                new object[] {null, "-42", -42m},
+                new object[] {null, "3,215", 3215m},
+                new object[] {null, "3.215", 3.215m}
             };
         }
 
@@ -48,23 +48,23 @@ namespace System.Linq.Dynamic.Core.Tests.Parser
         {
             return new object[][]
             {
-                new object[] { "de-DE", "1", 1f },
-                new object[] { "de-DE", "-42", -42f },
-                new object[] { "de-DE", "3,215", 3.215f },
-                new object[] { "de-DE", "3.215", 3215f },
-                new object[] { "de-DE", "1,2345E-4", 0.00012345f },
-                new object[] { "de-DE", "1,2345e-4", 0.00012345f },
-                new object[] { "de-DE", "1,2345E4", 12345d },
-                new object[] { "de-DE", "1,2345e4", 12345d },
+                new object[] {"de-DE", "1", 1f},
+                new object[] {"de-DE", "-42", -42f},
+                new object[] {"de-DE", "3,215", 3.215f},
+                new object[] {"de-DE", "3.215", 3215f},
+                new object[] {"de-DE", "1,2345E-4", 0.00012345f},
+                new object[] {"de-DE", "1,2345e-4", 0.00012345f},
+                new object[] {"de-DE", "1,2345E4", 12345d},
+                new object[] {"de-DE", "1,2345e4", 12345d},
 
-                new object[] { null, "1", 1f },
-                new object[] { null, "-42", -42f },
-                new object[] { null, "3,215", 3215f },
-                new object[] { null, "3.215", 3.215f },
-                new object[] { null, "1.2345E-4", 0.00012345f },
-                new object[] { null, "1.2345e-4", 0.00012345f },
-                new object[] { null, "1.2345E4", 12345f },
-                new object[] { null, "1.2345e4", 12345f }
+                new object[] {null, "1", 1f},
+                new object[] {null, "-42", -42f},
+                new object[] {null, "3,215", 3215f},
+                new object[] {null, "3.215", 3.215f},
+                new object[] {null, "1.2345E-4", 0.00012345f},
+                new object[] {null, "1.2345e-4", 0.00012345f},
+                new object[] {null, "1.2345E4", 12345f},
+                new object[] {null, "1.2345e4", 12345f}
             };
         }
 
@@ -89,23 +89,23 @@ namespace System.Linq.Dynamic.Core.Tests.Parser
         {
             return new object[][]
             {
-                new object[] { "de-DE", "1", 1d },
-                new object[] { "de-DE", "-42", -42d },
-                new object[] { "de-DE", "3,215", 3.215d },
-                new object[] { "de-DE", "3.215", 3215d },
-                new object[] { "de-DE", "1,2345E-4", 0.00012345d },
-                new object[] { "de-DE", "1,2345e-4", 0.00012345d },
-                new object[] { "de-DE", "1,2345E4", 12345d },
-                new object[] { "de-DE", "1,2345e4", 12345d },
+                new object[] {"de-DE", "1", 1d},
+                new object[] {"de-DE", "-42", -42d},
+                new object[] {"de-DE", "3,215", 3.215d},
+                new object[] {"de-DE", "3.215", 3215d},
+                new object[] {"de-DE", "1,2345E-4", 0.00012345d},
+                new object[] {"de-DE", "1,2345e-4", 0.00012345d},
+                new object[] {"de-DE", "1,2345E4", 12345d},
+                new object[] {"de-DE", "1,2345e4", 12345d},
 
-                new object[] { null, "1", 1d },
-                new object[] { null, "-42", -42d },
-                new object[] { null, "3,215", 3215d },
-                new object[] { null, "3.215", 3.215d },
-                new object[] { null, "1.2345E-4", 0.00012345d },
-                new object[] { null, "1.2345e-4", 0.00012345d },
-                new object[] { null, "1.2345E4", 12345d },
-                new object[] { null, "1.2345e4", 12345d }
+                new object[] {null, "1", 1d},
+                new object[] {null, "-42", -42d},
+                new object[] {null, "3,215", 3215d},
+                new object[] {null, "3.215", 3.215d},
+                new object[] {null, "1.2345E-4", 0.00012345d},
+                new object[] {null, "1.2345e-4", 0.00012345d},
+                new object[] {null, "1.2345E4", 12345d},
+                new object[] {null, "1.2345e4", 12345d}
             };
         }
 
@@ -158,17 +158,39 @@ namespace System.Linq.Dynamic.Core.Tests.Parser
         [InlineData("-42", 'm', -42)]
         [InlineData("42m", 'm', 42)]
         [InlineData("-42m", 'm', -42)]
+        public void NumberParser_ParseDecimalLiteral(string text, char qualifier, decimal expected)
+        {
+            // Arrange
 
+            // Act
+            var result = new NumberParser(_parsingConfig).ParseRealLiteral(text, qualifier, true) as ConstantExpression;
+
+            // Assert
+            result!.Value.Should().Be(expected);
+        }
+
+        [Theory]
         [InlineData("42", 'd', 42)]
         [InlineData("-42", 'd', -42)]
         [InlineData("42d", 'd', 42)]
         [InlineData("-42d", 'd', -42)]
+        public void NumberParser_ParseDoubleLiteral(string text, char qualifier, double expected)
+        {
+            // Arrange
 
+            // Act
+            var result = new NumberParser(_parsingConfig).ParseRealLiteral(text, qualifier, true) as ConstantExpression;
+
+            // Assert
+            result!.Value.Should().Be(expected);
+        }
+
+        [Theory]
         [InlineData("42", 'f', 42)]
         [InlineData("-42", 'f', -42)]
         [InlineData("42f", 'f', 42)]
         [InlineData("-42f", 'f', -42)]
-        public void NumberParser_ParseRealLiteral(string text, char qualifier, double expected)
+        public void NumberParser_ParseFloatLiteral(string text, char qualifier, float expected)
         {
             // Arrange
 

--- a/test/System.Linq.Dynamic.Core.Tests/Parser/NumberParserTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/Parser/NumberParserTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq.Dynamic.Core.Parser;
@@ -151,6 +151,32 @@ namespace System.Linq.Dynamic.Core.Tests.Parser
 
             // Assert
             result.Value.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("42", 'm', 42)]
+        [InlineData("-42", 'm', -42)]
+        [InlineData("42m", 'm', 42)]
+        [InlineData("-42m", 'm', -42)]
+
+        [InlineData("42", 'd', 42)]
+        [InlineData("-42", 'd', -42)]
+        [InlineData("42d", 'd', 42)]
+        [InlineData("-42d", 'd', -42)]
+
+        [InlineData("42", 'f', 42)]
+        [InlineData("-42", 'f', -42)]
+        [InlineData("42f", 'f', 42)]
+        [InlineData("-42f", 'f', -42)]
+        public void NumberParser_ParseRealLiteral(string text, char qualifier, double expected)
+        {
+            // Arrange
+
+            // Act
+            var result = new NumberParser(_parsingConfig).ParseRealLiteral(text, qualifier, true) as ConstantExpression;
+
+            // Assert
+            result!.Value.Should().Be(expected);
         }
     }
 }


### PR DESCRIPTION
**Description:**
There is an issue in the `ExpressionPromoter` class where the qualifier in the numeric literal expressions is not correctly handled, leading to incorrect type promotions. This is due to the way qualifiers are stored and retrieved from the `ConstantExpressionHelper`.

**Steps to Reproduce:**
1. Create an instance of `ParsingConfig`.
2. Use `NumberParser` to parse a numeric literal with a qualifier.
3. Attempt to promote the parsed expression to a different type using `ExpressionPromoter`.

**Example 1:**

```csharp
[Fact]
public void promoter()
{
    // Assign
    var parsingConfig = new ParsingConfig();
    var numberParser = new NumberParser(parsingConfig);
    var promoter = new ExpressionPromoter(parsingConfig);

    var doubleExpression = numberParser.ParseRealLiteral("10.5d", 'd', true);

    // Act & Assert
    var promotedExpression = promoter.Promote(doubleExpression, typeof(decimal), true, true);

    Assert.NotNull(promotedExpression);
    Assert.Equal(typeof(decimal), promotedExpression.Type);
}
```

**Example 2:**

```csharp
[Fact]
public void promoteDoubleToDecimal()
{
    // Assign
    var parsingConfig = new ParsingConfig();
    var numberParser = new NumberParser(parsingConfig);
    var promoter = new ExpressionPromoter(parsingConfig);

    var doubleExpression = numberParser.ParseRealLiteral("123.456d", 'd', true);

    // Act & Assert
    var promotedExpression = promoter.Promote(doubleExpression, typeof(decimal), true, true);

    Assert.NotNull(promotedExpression);
    Assert.Equal(typeof(decimal), promotedExpression.Type);
}
```

**Expected Behavior:**
The `Promote` method should correctly handle the qualifier and convert the numeric literal to the specified target type.

**Actual Behavior:**
The promotion fails, and the conversion does not occur as expected due to the incorrect handling of the qualifier in the `ConstantExpressionHelper`.

**Additional Information:**
This issue affects applications that rely on dynamic LINQ queries where numeric-type promotions with qualifiers are necessary.

**Proposed Solution:**
Ensure that the `CreateLiteral` in `ConstantExpressionHelper` correctly handles qualifiers without the prefix when creating and retrieving constant expressions.