### PR TITLE
Throw ArgumentException when expression has invalid compare (e.g. string with int)

### DIFF
--- a/src/System.Linq.Dynamic.Core/Compatibility/CodeAnalysis/NotNullWhenAttribute.cs
+++ b/src/System.Linq.Dynamic.Core/Compatibility/CodeAnalysis/NotNullWhenAttribute.cs
@@ -22,7 +22,7 @@
 // SOFTWARE.
 #endregion
 
-#if NETSTANDARD1_3_OR_GREATER || NET35 || NET40 || NET45 || NET452 || NET46 || NETCOREAPP2_1 || UAP10_0
+#if NETSTANDARD1_3 || NETSTANDARD2_0 || NET35 || NET40 || NET45 || NET452 || NET46 || NETCOREAPP2_1 || UAP10_0
 
 // ReSharper disable once CheckNamespace
 namespace System.Diagnostics.CodeAnalysis;

--- a/test/System.Linq.Dynamic.Core.Tests/Parser/ExpressionParserTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/Parser/ExpressionParserTests.cs
@@ -27,6 +27,10 @@ public partial class ExpressionParserTests
         D = 8,
     };
 
+    public class MyView
+    {
+        public Dictionary<string, string>? Properties { get; set; }
+    }
 
     public ExpressionParserTests()
     {
@@ -421,8 +425,18 @@ public partial class ExpressionParserTests
 
         // Act
         var parsedExpression = parser.Parse(typeof(string)).ToString();
-        
+
         // Assert
         parsedExpression.Should().Be(result);
+    }
+
+    [Fact]
+    public void Parse_InvalidExpressionShouldThrowArgumentException()
+    {
+        // Arrange & Act
+        Action act = () => DynamicExpressionParser.ParseLambda<MyView, bool>(ParsingConfig.Default, false, "Properties[\"foo\"] > 2", Array.Empty<object>());
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("Method 'Compare' not found on type 'System.String' or 'System.Int32'");
     }
 }


### PR DESCRIPTION
Modified `#if` directive in `NotNullWhenAttribute.cs` to include `NETSTANDARD2_0` and remove `NETSTANDARD1_3_OR_GREATER`. Updated `GenerateStaticMethodCall` in `ExpressionHelper.cs` to use `TryGetStaticMethod` instead of `GetStaticMethod`, throwing an `ArgumentException` if the method is not found. Replaced `GetStaticMethod` with `TryGetStaticMethod` in `ExpressionHelper.cs`. Added `MyView` class with nullable `Properties` dictionary to `ExpressionParserTests.cs`. Added `Parse_InvalidExpressionShouldThrowArgumentException` test to verify `ArgumentException` is thrown for invalid expressions.