### PR TITLE
Use MemberInfo to detect methods that should be allowed. 

### DIFF
--- a/src/System.Linq.Dynamic.Core/CustomTypeProviders/DefaultDynamicLinqCustomTypeProvider.cs
+++ b/src/System.Linq.Dynamic.Core/CustomTypeProviders/DefaultDynamicLinqCustomTypeProvider.cs
@@ -18,6 +18,7 @@ public class DefaultDynamicLinqCustomTypeProvider : AbstractDynamicLinqCustomTyp
     private readonly bool _cacheCustomTypes;
 
     private HashSet<Type>? _cachedCustomTypes;
+    private HashSet<MemberInfo>? _cachedCustomMemberInfos;
     private Dictionary<Type, List<MethodInfo>>? _cachedExtensionMethods;
 
      /// <summary>
@@ -65,6 +66,11 @@ public class DefaultDynamicLinqCustomTypeProvider : AbstractDynamicLinqCustomTyp
         }
 
         return GetCustomTypesInternal();
+    }
+
+    public virtual HashSet<MemberInfo> GetCustomMemberInfos()
+    {
+        return _cachedCustomMemberInfos ??= new HashSet<MemberInfo>();
     }
 
     /// <inheritdoc cref="IDynamicLinqCustomTypeProvider.GetExtensionMethods"/>

--- a/src/System.Linq.Dynamic.Core/CustomTypeProviders/IDynamicLinqCustomTypeProvider.cs
+++ b/src/System.Linq.Dynamic.Core/CustomTypeProviders/IDynamicLinqCustomTypeProvider.cs
@@ -9,10 +9,16 @@ namespace System.Linq.Dynamic.Core.CustomTypeProviders;
 public interface IDynamicLinqCustomTypeProvider
 {
     /// <summary>
-    /// Returns a list of custom types that System.Linq.Dynamic.Core will understand.
+    /// Returns a list of custom <see cref="Type"/> that System.Linq.Dynamic.Core will understand.
     /// </summary>
     /// <returns>A <see cref="HashSet{Type}" /> list of custom types.</returns>
     HashSet<Type> GetCustomTypes();
+
+    /// <summary>
+    /// Returns a list of custom <see cref="MemberInfo"/> that System.Linq.Dynamic.Core will understand.
+    /// </summary>
+    /// <returns>A <see cref="HashSet{MemberInfo}" /> list of custom <see cref="MemberInfo"/>.</returns>
+    HashSet<MemberInfo> GetCustomMemberInfos();
 
     /// <summary>
     /// Returns a list of custom extension methods that System.Linq.Dynamic.Core will understand.

--- a/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
@@ -1840,7 +1840,8 @@ public class ExpressionParser
 
                 case 1:
                     var method = (MethodInfo)methodBase!;
-                    if (!PredefinedTypesHelper.IsPredefinedType(_parsingConfig, method.DeclaringType!))
+                    if (!PredefinedTypesHelper.IsPredefinedType(_parsingConfig, method.DeclaringType!)
+                        && !PredefinedTypesHelper.IsPredefinedMember(_parsingConfig, methodBase!))
                     {
                         throw ParseError(errorPos, Res.MethodsAreInaccessible, TypeHelper.GetTypeName(method.DeclaringType!));
                     }

--- a/test/System.Linq.Dynamic.Core.Tests/DynamicClassTest.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/DynamicClassTest.cs
@@ -281,8 +281,7 @@ public class DynamicClassTest
         isValid.Should().BeFalse(); // This should actually be true, but fails. For solution see Issue593_Solution1 and Issue593_Solution2.
     }
 
-    // [SkipIfGitHubActions]
-    [Fact(Skip = "867")]
+    [SkipIfGitHubActions]
     public void DynamicClassArray_Issue593_Solution1()
     {
         // Arrange

--- a/test/System.Linq.Dynamic.Core.Tests/DynamicExpressionParserTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/DynamicExpressionParserTests.cs
@@ -1058,7 +1058,7 @@ public class DynamicExpressionParserTests
         Assert.Equal(expectedRightValue, rightValue);
     }
 
-    [Fact(Skip = "867")]
+    [Fact]
     public void DynamicExpressionParser_ParseLambda_TupleToStringMethodCall_ReturnsStringLambdaExpression()
     {
         var expression = DynamicExpressionParser.ParseLambda(

--- a/test/System.Linq.Dynamic.Core.Tests/Parser/ExpressionParserTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/Parser/ExpressionParserTests.cs
@@ -346,7 +346,7 @@ public partial class ExpressionParserTests
     [Theory]
     [InlineData("it.MainCompany.Name != null", "(company.MainCompany.Name != null)")]
     [InlineData("@MainCompany.Companies.Count() > 0", "(company.MainCompany.Companies.Count() > 0)")]
-    // [InlineData("Company.Equals(null, null)", "Equals(null, null)")] issue 867
+    [InlineData("Company.Equals(null, null)", "Equals(null, null)")]
     [InlineData("MainCompany.Name", "company.MainCompany.Name")]
     [InlineData("Name", "company.Name")]
     [InlineData("company.Name", "company.Name")]

--- a/test/System.Linq.Dynamic.Core.Tests/Parser/MethodFinderTest.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/Parser/MethodFinderTest.cs
@@ -7,7 +7,7 @@ namespace System.Linq.Dynamic.Core.Tests.Parser;
 
 public class MethodFinderTest
 {
-    [Fact(Skip = "867")]
+    [Fact]
     public void MethodsOfDynamicLinqAndSystemLinqShouldBeEqual()
     {
         Expression<Func<int?, string?>> expr = x => x.ToString();


### PR DESCRIPTION
Add Equals and ToString from object to allowed as default.

Note: Was not able to run the code locally because of missing workloads in Visual Studio.

@StefH Can this be a way forward to make the object.Equal and object.ToString to work as well?