### PR TITLE
DynamicExpressionParser - Handle indexed properties with any number of indices in expression

### DIFF
--- a/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
+++ b/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs
@@ -2353,8 +2353,7 @@ public class ExpressionParser
         switch (_methodFinder.FindIndexer(expr.Type, args, out var mb))
         {
             case 0:
-                throw ParseError(errorPos, Res.NoApplicableIndexer,
-                    TypeHelper.GetTypeName(expr.Type));
+                throw ParseError(errorPos, Res.NoApplicableIndexer, TypeHelper.GetTypeName(expr.Type), args.Length);
 
             case 1:
                 var indexMethod = (MethodInfo)mb!;

--- a/src/System.Linq.Dynamic.Core/Res.cs
+++ b/src/System.Linq.Dynamic.Core/Res.cs
@@ -55,7 +55,7 @@ internal static class Res
     public const string MissingAsClause = "Expression is missing an 'as' clause";
     public const string NeitherTypeConvertsToOther = "Neither of the types '{0}' and '{1}' converts to the other";
     public const string NewOperatorIsNotAllowed = "Using the new operator is not allowed via the ParsingConfig.";
-    public const string NoApplicableIndexer = "No applicable indexer exists in type '{0}'";
+    public const string NoApplicableIndexer = "No applicable indexer exists in type '{0}' with {1} parameters";
     public const string NoApplicableMethod = "No applicable method '{0}' exists in type '{1}'";
     public const string NoItInScope = "No 'it' is in scope";
     public const string NoMatchingConstructor = "No matching constructor in type '{0}'";

--- a/test/System.Linq.Dynamic.Core.Tests/DynamicExpressionParserTests.cs
+++ b/test/System.Linq.Dynamic.Core.Tests/DynamicExpressionParserTests.cs
@@ -725,6 +725,25 @@ public class DynamicExpressionParserTests
         // Assert
         Check.That(result).Equals("3-1");
     }
+    
+    [Fact]
+    public void DynamicExpressionParser_ParseLambda_IndexerParameterMismatch()
+    {
+        // Arrange
+        var customTypeProvider = new Mock<IDynamicLinqCustomTypeProvider>();
+        customTypeProvider.Setup(c => c.GetCustomTypes()).Returns([typeof(ClassWithIndexers)]);
+        var config = new ParsingConfig
+        {
+            CustomTypeProvider = customTypeProvider.Object
+        };
+        var expressionParams = new[]
+        {
+            Expression.Parameter(typeof(ClassWithIndexers), "myObj")
+        };
+        
+        Assert.Throws<ParseException>(() =>
+            DynamicExpressionParser.ParseLambda(config, false, expressionParams, null, "myObj[3,\"1\",1]"));
+    }
 
     [Fact]
     public void DynamicExpressionParser_ParseLambda_DuplicateParameterNames_ThrowsException()


### PR DESCRIPTION
## Issue

Currently, when trying to parse with `DynamicExpressionParser an expression container an indexed property with more than 1 index, it would throw with the following exception (cf. added unit test illustrating the issue)

```
System.ArgumentException: Incorrect number of arguments supplied for call to method 'System.String get_Item(Int32, System.String)' (Parameter 'method'...

System.ArgumentException
Incorrect number of arguments supplied for call to method 'System.String get_Item(Int32, System.String)' (Parameter 'method')
   at System.Dynamic.Utils.ExpressionUtils.ValidateArgumentCount(MethodBase method, ExpressionType nodeKind, Int32 count, ParameterInfo[] pis)
   at System.Linq.Expressions.Expression.Call(Expression instance, MethodInfo method, Expression arg0)
   at System.Linq.Expressions.Expression.Call(Expression instance, MethodInfo method, IEnumerable`1 arguments)
   at System.Linq.Dynamic.Core.Parser.ExpressionParser.ParseElementAccess(Expression expr) in /Users/thibault/Code/System.Linq.Dynamic.Core/src/System.Linq.Dynamic.Core/Parser/ExpressionParser.cs:line 2369

```

The fix is rather straightforward, consisting in removing the hardcoded assumption that .NET indexer can't have more than 1 index parameter.